### PR TITLE
Initial FMA code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This library provides a C++ implementation of the HUB format with configurable e
 
 - **Configurable Precision**
 - **Standard Arithmetic Operations**
+- **FMA Emulation**
 - **Special Value Handling**
 - **Conversion Support**
 - **Diagnostic Functions**
@@ -55,6 +56,7 @@ The implementation uses a double as the internal storage format, with bit manipu
 - Special case handling for values like infinity, NaN, and subnormals
 - Proper extraction of bit fields for string representations
 - Support for all basic arithmetic operations
+- Detection and correction of double rounding in float32 FMA emulation (EXP_BITS=8, MANT_BITS=23) for accurate single-precision results
 
 ## References
 

--- a/src/hub_float.hpp
+++ b/src/hub_float.hpp
@@ -246,6 +246,21 @@ public:
     friend hub_float sqrt(const hub_float& x);
 
    /*
+       Friend Function: fma
+       Fused multiply-add function for hub_float.
+       Computes (a*b + c) with only one rounding operation using hardware FMA.
+
+       Parameters:
+       a - The first hub_float to multiply.
+       b - The second hub_float to multiply.
+       c - The hub_float to add to the product.
+
+       Returns:
+       The result of (a*b + c) as a hub_float.
+   */
+    friend hub_float fma(const hub_float& a, const hub_float& b, const hub_float& c);
+
+   /*
        Friend Function: operator<<
        Stream insertion operator for hub_float.
 


### PR DESCRIPTION
- Added fused multiply-add support
  - src/hub_float.hpp: added friend declaration for fma(const hub_float&, const hub_float&, const hub_float&).
  - src/hub_float.cpp: implemented fma using std::fma; result is quantized to the HUB grid.

- Double-rounding detection and correction for float32 emulation
  - src/hub_float.cpp: inside fma, added detection logic and corrective adjustment (subtract 1 ULP) when compiling for float32 configuration (EXP_BITS==8, MANT_BITS==23). The logic is guarded by preprocessor checks and only affects the float32-emulation path.

- Documentation updates
  - README.md: added FMA emulation to Features and clarified that double-rounding is detected and corrected when emulating float32 to ensure correct single-precision results.

Notes
- The fma implementation relies on hardware std::fma for the main computation and then applies HUB quantization.
- The double-rounding correction is conditional and documented in the function's comment block.
- No API surface changes beyond the new friend function declaration; existing operations and file layout remain unchanged.